### PR TITLE
Added minimum left and top properties for positioning the dialog

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -178,6 +178,8 @@
 		minWidth: null,
 		maxHeight: null,
 		maxWidth: null,
+		minLeft: 0,
+		minTop: 0,
 		autoResize: false,
 		autoPosition: true,
 		zIndex: 1000,
@@ -582,6 +584,11 @@
 				top = hc;
 				left = vc;
 			}
+
+			// Enforce minimum position (useful for keeping dialog within window boundries)
+            left = left < s.o.minLeft ? s.o.minLeft : left;
+            top = top < s.o.minTop ? s.o.minTop : top;
+
 			s.d.container.css({left: left, top: top});
 		},
 		watchTab: function (e) {


### PR DESCRIPTION
Hey Eric, I noticed that if you size down the browser, it doesn't constrain the top or left position properties. This causes the dialog to be positioned "off screen" in a window that is shorter or narrower than the centered dialog.

I added two options for minLeft and minTop (with generic defaults of 0) to check against when calculating position.

Hope you find this as useful as I did, thanks!
