### PR TITLE
Change container height to match content height on update

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -549,7 +549,7 @@
 				}
 			}
 			else {
-				ch = s.o.autoResize && ch < dh ? dh : ch
+				ch = s.o.autoResize && dh ? dh : ch;
 				ch = s.o.autoResize && ch > mh ? mh : ch < moh ? moh : ch;
 			}
 


### PR DESCRIPTION
Hi Eric,

Thank you for providing this plugin. I found I had to modify it locally a little bit to suit my scenario. My modal dialog loads content via AJAX based on certain user events. The returned data may cause the dialog's contents to grow beyond the height of the container. With autoResize the container would just start scrolling vertically (overflow:auto) instead of increasing its height (to min(max height, height of content)).

The change in my branch solves this problem for me, but I haven't had a chance to test it much and I haven't worked with your library for very long. Please let me know if there is a better way to solve this problem or if my fix isn't complete.

Thanks,
Dmitri
