### PR TITLE
Using window.innerHeight where available to avoid widespread jQuery height() bugs

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -494,7 +494,7 @@
 		getDimensions: function () {
 			// fix a jQuery bug with determining the window height - use innerHeight if available
 			var s = this,
-				h = typeof window.innerHeight == 'undefined' ? wndw.height() : window.innerHeight;
+				h = typeof window.innerHeight === 'undefined' ? wndw.height() : window.innerHeight;
 
 			d = [doc.height(), doc.width()];
 			w = [h, wndw.width()];


### PR DESCRIPTION
Found another instance where jQuery's $('window').height() was returning inaccurate values (iOS Safari).  Changed getDimensions() to test for the innerHeight property and use it whenever available.
