### PR TITLE
jquery 1.7.1 + jasmine unit tests + IE bug

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -366,7 +366,9 @@
 
 			// fix issues with IE
 			if (ie6 || ieQuirks) {
-				s.fixIE();
+				try {
+		                    s.fixIE();
+		                } catch (e) {}
 			}
 		},
 		/*


### PR DESCRIPTION
jquery 1.7.1 + jasmine unit tests + IE in standart mode caused "not implemented" error

issue was with with .removeExpression

strange ussue, easy fixed with try/catch + protects in the future
