### PR TITLE
Update getDimensions function to ensure that w[] has non-zero values

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -497,7 +497,16 @@
 				h = typeof window.innerHeight === 'undefined' ? wndw.height() : window.innerHeight;
 
 			d = [doc.height(), doc.width()];
-			w = [h, wndw.width()];
+			
+			// make sure that w is recording real numbers. 
+			// In case wndw.height() or .width() is not working, use numbers from doc instead (better than nothing)
+			var heightToUse = h == 0 ? d[0] : h;
+			var widthToUse = wndw.width();
+			if (widthToUse == 0) {
+        widthToUse = d[1];
+			}
+			w = [heightToUse, widthToUse];
+			
 		},
 		getVal: function (v, d) {
 			return v ? (typeof v === 'number' ? v


### PR DESCRIPTION
Ran into a bug using simplemodal on IE9 where wndw.Width() and .height() as used in the getDimensions function returned zero. This resulted in top/left being set to the wrong numbers, modal being off-center. Corrected by checking in getDimensions that values are > 0 before initializing the w[] array with them.
