### PR TITLE
a bug in ie7-8

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -335,7 +335,7 @@
 				.attr('id', s.o.containerId)
 				.addClass('simplemodal-container')
 				.css($.extend(
-					{position: s.o.fixed ? 'fixed' : 'absolute'},
+					{position: s.o.fixed ? 'fixed' : 'absolute', 'height' : '0'},
 					s.o.containerCss,
 					{display: 'none', zIndex: s.o.zIndex + 2}
 				))


### PR DESCRIPTION
hi, I use simplemodal in ie7/ie8, but sometime, when it show it loses height
I test the code, find that add 'height: 0' can fix it.
