### PR TITLE
Replaced HTML does not trigger modal close for elements with closeClass

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -376,7 +376,7 @@
 			var s = this;
 
 			// bind the close event to any element with the closeClass class
-			$('.' + s.o.closeClass).bind('click.simplemodal', function (e) {
+			s.d.container.delegate('.' + s.o.closeClass, 'click.simplemodal', function (e) {
 				e.preventDefault();
 				s.close();
 			});
@@ -422,7 +422,7 @@
 		 * Unbind events
 		 */
 		unbindEvents: function () {
-			$('.' + this.o.closeClass).unbind('click.simplemodal');
+			s.d.container.undelegate('.' + s.o.closeClass, 'click.simplemodal');
 			doc.unbind('keydown.simplemodal');
 			wndw.unbind('.simplemodal');
 			this.d.overlay.unbind('click.simplemodal');


### PR DESCRIPTION
If the html is late loaded into the modal or the html in the modal is changed, elements with the close class do not trigger close as the event is bound directly to the element vs the container element.

Since I was unsure what versions of jQuery you were supporting I used $.delegate vs $.on but please let me know if you prefer this to be changed to $.on

Thanks,
Dan
