### PR TITLE
fix for latest versions of jQuery

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -238,7 +238,7 @@
 			}
 
 			// $.support.boxModel is undefined if checked earlier
-			browser.ieQuirks = browser.msie && !$.support.boxModel;
+			browser.ieQuirks = browser.msie && !($.support.boxModel===undefined) && !$.support.boxModel;
 
 			// merge defaults and user options
 			s.o = $.extend({}, $.modal.defaults, options);


### PR DESCRIPTION
support.boxModel has been removed from the latest versions of jQuery
http://bugs.jquery.com/ticket/13743

change to check if support.boxModel exists as part of the
browser.ieQuirks test
