### PR TITLE
Hotfix for the ie10 issue

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -85,7 +85,6 @@
 	};
 	browser.ie6 = browser.msie && /msie 6./.test(ua) && typeof window['XMLHttpRequest'] !== 'object';
 	browser.ie7 = browser.msie && /msie 7.0/.test(ua);
-	browser.expression = true;
 
 	/*
 	 * Feature-Detection for Expression


### PR DESCRIPTION
Method "removeExpression" caused ie10 to fail...
