### PR TITLE
Modernized version of SimpleModal

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -40,11 +40,10 @@
  * dialog can be created at a time. Which means that all of the matched
  * elements will be displayed within the modal container.
  *
- * SimpleModal internally sets the CSS needed to display the modal dialog
- * properly in all browsers, yet provides the developer with the flexibility
- * to easily control the look and feel. The styling for SimpleModal can be
- * done through external stylesheets, or through SimpleModal, using the
- * overlayCss, containerCss, and dataCss options.
+ * SimpleModal does not set any styling on modals, but rather provides the
+ * developer with the flexibility to easily control the look and feel by
+ * creating their own CSS in combination with the overlayCss, containerCss,
+ * and dataCss options.
  *
  * @name SimpleModal
  * @type jQuery
@@ -90,36 +89,17 @@
 	/*
 	 * Set focus on first or last visible input in the modal dialog. To focus on the last
 	 * element, call $.modal.focus('last'). If no input elements are found, focus is placed
-	 * on the data wrapper element.
+	 * on the data element.
 	 */
 	$.modal.focus = function (pos) {
 		$.modal.impl.focus(pos);
 	};
 
 	/*
-	 * Determine and set the dimensions of the modal dialog container.
-	 * setPosition() is called if the autoPosition option is true.
+	 * Update the modal dialog. Re-bind events. Focus, if "focus" option is enabled.
 	 */
-	$.modal.setContainerDimensions = function () {
-		$.modal.impl.setContainerDimensions();
-	};
-
-	/*
-	 * Re-position the modal dialog.
-	 */
-	$.modal.setPosition = function () {
-		$.modal.impl.setPosition();
-	};
-
-	/*
-	 * Update the modal dialog. If new dimensions are passed, they will be used to determine
-	 * the dimensions of the container.
-	 *
-	 * setContainerDimensions() is called, which in turn calls setPosition(), if enabled.
-	 * Lastly, focus() is called is the focus option is true.
-	 */
-	$.modal.update = function (height, width) {
-		$.modal.impl.update(height, width);
+	$.modal.update = function () {
+		$.modal.impl.update();
 	};
 
 	/*
@@ -143,13 +123,6 @@
 	 * containerCss:	(Object:{}) The CSS styling for the container div
 	 * dataId:			(String:'simplemodal-data') The DOM element id for the data div
 	 * dataCss:			(Object:{}) The CSS styling for the data div
-	 * minHeight:		(Number:null) The minimum height for the container
-	 * minWidth:		(Number:null) The minimum width for the container
-	 * maxHeight:		(Number:null) The maximum height for the container. If not specified, the window height is used.
-	 * maxWidth:		(Number:null) The maximum width for the container. If not specified, the window width is used.
-	 * autoResize:		(Boolean:false) Automatically resize the container if it exceeds the browser window dimensions?
-	 * autoPosition:	(Boolean:true) Automatically position the container upon creation and on window resize?
-	 * zIndex:			(Number: 1000) Starting z-index value
 	 * close:			(Boolean:true) If true, closeHTML, escClose and overClose will be used if set.
 	 							If false, none of them will be used.
 	 * closeHTML:		(String:'<a class="modalCloseImg" title="Close"></a>') The HTML for the default close link.
@@ -164,7 +137,7 @@
 								DOM elements. If true, the data will be maintained across modal calls, if false,
 								the data will be reverted to its original state.
 	 * modal:			(Boolean:true) User will be unable to interact with the page below the modal or tab away from the dialog.
-								If false, the overlay, iframe, and certain events will be disabled allowing the user to interact
+								If false, the overlay and certain events will be disabled allowing the user to interact
 								with the page below the dialog.
 	 * onOpen:			(Function:null) The callback function used in place of SimpleModal's open
 	 * onShow:			(Function:null) The callback function used after the modal dialog has opened
@@ -180,13 +153,6 @@
 		containerCss: {},
 		dataId: 'simplemodal-data',
 		dataCss: {},
-		minHeight: null,
-		minWidth: null,
-		maxHeight: null,
-		maxWidth: null,
-		autoResize: false,
-		autoPosition: true,
-		zIndex: 1000,
 		close: true,
 		closeHTML: '<a class="modalCloseImg" title="Close"></a>',
 		closeClass: 'simplemodal-close',
@@ -225,9 +191,6 @@
 			// merge defaults and user options
 			s.o = $.extend({}, $.modal.defaults, options);
 
-			// keep track of z-index
-			s.zIndex = s.o.zIndex;
-
 			// set the onClose callback flag
 			s.occb = false;
 
@@ -262,7 +225,7 @@
 				return s;
 			}
 
-			// create the modal overlay, container and, if necessary, iframe
+			// create the modal overlay and container
 			s.create(data);
 			data = null;
 
@@ -283,58 +246,37 @@
 		create: function (data) {
 			var s = this;
 
-			// get the window properties
-			s.getDimensions();
-
 			// create the overlay
 			s.d.overlay = $('<div></div>')
 				.attr('id', s.o.overlayId)
 				.addClass('simplemodal-overlay')
-				.css($.extend(s.o.overlayCss, {
-					display: 'none',
-					opacity: s.o.opacity / 100,
-					height: s.o.modal ? d[0] : 0,
-					width: s.o.modal ? d[1] : 0,
-					position: 'fixed',
-					left: 0,
-					top: 0,
-					zIndex: s.o.zIndex + 1
-				}))
 				.appendTo(s.o.appendTo);
 
 			// create the container
 			s.d.container = $('<div></div>')
 				.attr('id', s.o.containerId)
 				.addClass('simplemodal-container')
-				.css($.extend(
-					{position: s.o.fixed ? 'fixed' : 'absolute'},
-					s.o.containerCss,
-					{display: 'none', zIndex: s.o.zIndex + 2}
-				))
-				.append(s.o.close && s.o.closeHTML
-					? $(s.o.closeHTML).addClass(s.o.closeClass)
-					: '')
 				.appendTo(s.o.appendTo);
 
-			s.d.wrap = $('<div></div>')
-				.attr('tabIndex', -1)
-				.addClass('simplemodal-wrap')
-				.css({height: '100%', outline: 0, width: '100%'})
-				.appendTo(s.d.container);
+			if (s.o.close && s.o.closeHTML) {
+				// add user specified close button
+				s.d.container.append(
+					$(s.o.closeHTML).addClass(s.o.closeClass)
+				);
+			}
 
-			// add styling and attributes to the data
-			// append to body to get correct dimensions, then move to wrap
+			// add attributes to the data
 			s.d.data = data
 				.attr('id', data.attr('id') || s.o.dataId)
 				.addClass('simplemodal-data')
-				.css($.extend(s.o.dataCss, {
-						display: 'none'
-				}))
-				.appendTo('body');
-			data = null;
+				.hide();
 
-			s.setContainerDimensions();
-			s.d.data.appendTo(s.d.wrap);
+			if (s.o.dataCss) {
+				// apply user specified styles
+				s.d.data.css(s.o.dataCss);
+			}
+
+			s.d.data.appendTo(s.d.container);
 		},
 		/*
 		 * Bind events
@@ -366,21 +308,6 @@
 					s.close();
 				}
 			});
-
-			// update window size
-			wndw.bind('resize.simplemodal orientationchange.simplemodal', function () {
-				// redetermine the window width/height
-				s.getDimensions();
-
-				// reposition the dialog
-				s.o.autoResize ? s.setContainerDimensions() : s.o.autoPosition && s.setPosition();
-
-				if (s.o.modal) {
-					// update the iframe & overlay
-					s.d.iframe && s.d.iframe.css({height: w[0], width: w[1]});
-					s.d.overlay.css({height: d[0], width: d[1]});
-				}
-			});
 		},
 		/*
 		 * Unbind events
@@ -397,32 +324,16 @@
 		focus: function (pos) {
 			var s = this, p = pos && $.inArray(pos, ['first', 'last']) !== -1 ? pos : 'first';
 
-			// focus on dialog or the first visible/enabled input element
-			var input = $(':input:enabled:visible:' + p, s.d.wrap);
+			// focus on first visible/enabled input element or dialog
+			var input = $(':input:enabled:visible:' + p, s.d.data);
 			setTimeout(function () {
-				input.length > 0 ? input.focus() : s.d.wrap.focus();
+				(input.length ? input : s.d.data).focus();
 			}, 10);
 		},
-		getDimensions: function () {
-			// fix a jQuery bug with determining the window height - use innerHeight if available
-			var s = this,
-				h = typeof window.innerHeight === 'undefined' ? wndw.height() : window.innerHeight;
-
-			d = [doc.height(), doc.width()];
-			w = [h, wndw.width()];
-		},
-		getVal: function (v, d) {
-			return v ? (typeof v === 'number' ? v
-					: v === 'auto' ? 0
-					: v.indexOf('%') > 0 ? ((parseInt(v.replace(/%/, '')) / 100) * (d === 'h' ? w[0] : w[1]))
-					: parseInt(v.replace(/px/, '')))
-				: null;
-		},
 		/*
-		 * Update the container. Set new dimensions, if provided.
-		 * Focus, if enabled. Re-bind events.
+		 * Update the container. Focus, if enabled. Re-bind events.
 		 */
-		update: function (height, width) {
+		update: function () {
 			var s = this;
 
 			// prevent update if dialog does not exist
@@ -430,85 +341,12 @@
 				return false;
 			}
 
-			// reset orig values
-			s.d.origHeight = s.getVal(height, 'h');
-			s.d.origWidth = s.getVal(width, 'w');
-
-			// hide data to prevent screen flicker
-			s.d.data.hide();
-			height && s.d.container.css('height', height);
-			width && s.d.container.css('width', width);
-			s.setContainerDimensions();
 			s.d.data.show();
 			s.o.focus && s.focus();
 
 			// rebind events
 			s.unbindEvents();
 			s.bindEvents();
-		},
-		setContainerDimensions: function () {
-			var s = this;
-
-			// get the dimensions for the container and data
-			var ch = s.d.origHeight ? s.d.origHeight : s.getVal(s.d.container.css('height'), 'h'),
-				cw = s.d.origWidth ? s.d.origWidth : s.getVal(s.d.container.css('width'), 'w'),
-				dh = s.d.data.outerHeight(true), dw = s.d.data.outerWidth(true);
-
-			s.d.origHeight = s.d.origHeight || ch;
-			s.d.origWidth = s.d.origWidth || cw;
-
-			// mxoh = max option height, mxow = max option width
-			var mxoh = s.o.maxHeight ? s.getVal(s.o.maxHeight, 'h') : null,
-				mxow = s.o.maxWidth ? s.getVal(s.o.maxWidth, 'w') : null,
-				mh = mxoh && mxoh < w[0] ? mxoh : w[0],
-				mw = mxow && mxow < w[1] ? mxow : w[1];
-
-			// moh = min option height
-			var moh = s.o.minHeight ? s.getVal(s.o.minHeight, 'h') : 'auto';
-			if (!ch) {
-				if (!dh) {ch = moh;}
-				else {
-					if (dh > mh) {ch = mh;}
-					else if (s.o.minHeight && moh !== 'auto' && dh < moh) {ch = moh;}
-					else {ch = dh;}
-				}
-			}
-			else {
-				ch = s.o.autoResize && ch > mh ? mh : ch < moh ? moh : ch;
-			}
-
-			// mow = min option width
-			var mow = s.o.minWidth ? s.getVal(s.o.minWidth, 'w') : 'auto';
-			if (!cw) {
-				if (!dw) {cw = mow;}
-				else {
-					if (dw > mw) {cw = mw;}
-					else if (s.o.minWidth && mow !== 'auto' && dw < mow) {cw = mow;}
-					else {cw = dw;}
-				}
-			}
-			else {
-				cw = s.o.autoResize && cw > mw ? mw : cw < mow ? mow : cw;
-			}
-
-			s.d.container.css({height: ch, width: cw});
-			s.d.wrap.css({overflow: (dh > ch || dw > cw) ? 'auto' : 'visible'});
-			s.o.autoPosition && s.setPosition();
-		},
-		setPosition: function () {
-			var s = this, top, left,
-				hc = (w[0]/2) - (s.d.container.outerHeight(true)/2),
-				vc = (w[1]/2) - (s.d.container.outerWidth(true)/2),
-				st = s.d.container.css('position') !== 'fixed' ? wndw.scrollTop() : 0;
-
-			if (s.o.position && Object.prototype.toString.call(s.o.position) === '[object Array]') {
-				top = st + (s.o.position[0] || hc);
-				left = s.o.position[1] || vc;
-			} else {
-				top = st + hc;
-				left = vc;
-			}
-			s.d.container.css({left: left, top: top});
 		},
 		watchTab: function (e) {
 			var s = this;
@@ -536,12 +374,9 @@
 		 * Open the modal dialog elements
 		 * - Note: If you use the onOpen callback, you must "show" the
 		 *         overlay and container elements manually
-		 *         (the iframe will be handled by SimpleModal)
 		 */
 		open: function () {
 			var s = this;
-			// display the iframe
-			s.d.iframe && s.d.iframe.show();
 
 			if ($.isFunction(s.o.onOpen)) {
 				// execute the onOpen callback
@@ -562,7 +397,7 @@
 		/*
 		 * Close the modal dialog
 		 * - Note: If you use an onClose callback, you must remove the
-		 *         overlay, container and iframe elements manually
+		 *         overlay and container elements manually
 		 *
 		 * @param {boolean} external Indicates whether the call to this
 		 *     function was internal or external. If it was external, the
@@ -609,9 +444,7 @@
 
 				// remove the remaining elements
 				s.d.container.hide().remove();
-				s.d.overlay.hide();
-				s.d.iframe && s.d.iframe.hide().remove();
-				s.d.overlay.remove();
+				s.d.overlay.hide().remove();
 
 				// reset the dialog object
 				s.d = {};


### PR DESCRIPTION
- remove all browser-specific hacks and references to specific browsers
- remove all positioning and dimension setting code
- remove all options to do with width/height control
- remove the `.simplemodal-wrap` element from HTML

By realizing these changes, it is possible to control modals entirely using CSS, without having to negate the styles that SimpleModal applies by default. Removing large blocks of code for legacy browsers makes SimpleModal even faster.

cc @rjmackay @dkobia 
