### PR TITLE
Complement onShow with onHide

### DIFF
--- a/src/jquery.simplemodal.js
+++ b/src/jquery.simplemodal.js
@@ -184,6 +184,7 @@
 								with the page below the dialog.
 	 * onOpen:			(Function:null) The callback function used in place of SimpleModal's open
 	 * onShow:			(Function:null) The callback function used after the modal dialog has opened
+	 * onHide:			(Function:null) The callback function used before the modal dialog is closed
 	 * onClose:			(Function:null) The callback function used in place of SimpleModal's close
 	 */
 	$.modal.defaults = {
@@ -214,6 +215,7 @@
 		modal: true,
 		onOpen: null,
 		onShow: null,
+		onHide: null,
 		onClose: null
 	};
 
@@ -224,7 +226,7 @@
 	$.modal.impl = {
 		/*
 		 * Contains the modal dialog elements and is the object passed
-		 * back to the callback (onOpen, onShow, onClose) functions
+		 * back to the callback (onOpen, onShow, onHide, onClose) functions
 		 */
 		d: {},
 		/*
@@ -669,6 +671,11 @@
 			// prevent close when dialog does not exist
 			if (!s.d.data) {
 				return false;
+			}
+
+			// useful for removing events/manipulating data in the modal dialog before closing
+			if ($.isFunction(s.o.onHide)) {
+				s.o.onHide.apply(s, [s.d]);
 			}
 
 			// remove the default events


### PR DESCRIPTION
Like `onShow`, adding an `onHide` method that is called before `onClose` is executed.